### PR TITLE
feat: implement folder creation and breadcrumb navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ bucketboard/
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/your-username/bucketboard.git
+git clone https://github.com/yogeshkoli/bucketboard.git
 cd bucketboard
 ```
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect, useCallback } from 'react';
 import { FileList, type FileListData } from '@/components/FileList';
 import { UploadDialog } from '@/components/UploadDialog';
+import { CreateFolderDialog } from '@/components/CreateFolderDialog';
+import { BreadcrumbNav } from '@/components/BreadcrumbNav';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Terminal } from 'lucide-react';
@@ -86,12 +88,13 @@ export default function HomePage() {
       <div className="border rounded-lg">
         <div className="flex items-center justify-between p-4 border-b">
           <div>
-            <h1 className="text-xl font-semibold">BucketBoard</h1>
-            <p className="text-sm text-muted-foreground">
-              Browsing: {process.env.NEXT_PUBLIC_AWS_BUCKET_NAME || 'your-bucket'}/{prefix}
-            </p>
+            <h1 className="text-xl font-semibold mb-2">BucketBoard</h1>
+            <BreadcrumbNav prefix={prefix} onNavigate={setPrefix} />
           </div>
-          <UploadDialog currentPrefix={prefix} onUploadSuccess={fetchFiles} />
+          <div className="flex items-center gap-2">
+            <CreateFolderDialog currentPrefix={prefix} onSuccess={fetchFiles} />
+            <UploadDialog currentPrefix={prefix} onUploadSuccess={fetchFiles} />
+          </div>
         </div>
         {loading && <FileListSkeleton />}
         {error && (

--- a/frontend/src/components/BreadcrumbNav.tsx
+++ b/frontend/src/components/BreadcrumbNav.tsx
@@ -1,0 +1,32 @@
+import { Home, ChevronRight } from 'lucide-react';
+
+interface BreadcrumbNavProps {
+    prefix: string;
+    onNavigate: (path: string) => void;
+}
+
+export function BreadcrumbNav({ prefix, onNavigate }: BreadcrumbNavProps) {
+    const segments = prefix.split('/').filter(Boolean);
+
+    const handleNavigate = (index: number) => {
+        const newPrefix = segments.slice(0, index + 1).join('/') + '/';
+        onNavigate(newPrefix);
+    };
+
+    return (
+        <nav className="flex items-center text-sm text-muted-foreground">
+            <button onClick={() => onNavigate('')} className="flex items-center hover:text-primary">
+                <Home className="h-4 w-4 mr-2" />
+                {process.env.NEXT_PUBLIC_AWS_BUCKET_NAME || 'your-bucket'}
+            </button>
+            {segments.map((segment, index) => (
+                <div key={index} className="flex items-center">
+                    <ChevronRight className="h-4 w-4 mx-1" />
+                    {index < segments.length - 1 ? (
+                        <button onClick={() => handleNavigate(index)} className="hover:text-primary">{segment}</button>
+                    ) : (<span className="font-medium text-foreground">{segment}</span>)}
+                </div>
+            ))}
+        </nav>
+    );
+}

--- a/frontend/src/components/CreateFolderDialog.tsx
+++ b/frontend/src/components/CreateFolderDialog.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+    DialogFooter,
+    DialogClose,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { FolderPlus } from 'lucide-react';
+
+interface CreateFolderDialogProps {
+    currentPrefix: string;
+    onSuccess: () => void;
+}
+
+export function CreateFolderDialog({ currentPrefix, onSuccess }: CreateFolderDialogProps) {
+    const [folderName, setFolderName] = useState('');
+    const [error, setError] = useState('');
+    const [isOpen, setIsOpen] = useState(false);
+
+    const handleCreate = async () => {
+        if (!folderName || folderName.includes('/')) {
+            setError('Invalid folder name. Cannot be empty or contain slashes.');
+            return;
+        }
+        setError('');
+
+        try {
+            const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/folders`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ folderName, prefix: currentPrefix }),
+            });
+
+            if (!res.ok) {
+                const errorData = await res.json();
+                throw new Error(errorData.details || 'Failed to create folder.');
+            }
+
+            onSuccess();
+            setIsOpen(false);
+            setFolderName('');
+        } catch (e) {
+            if (e instanceof Error) {
+                setError(e.message);
+            } else {
+                setError('An unexpected error occurred.');
+            }
+        }
+    };
+
+    return (
+        <Dialog open={isOpen} onOpenChange={setIsOpen}>
+            <DialogTrigger asChild>
+                <Button variant="outline"><FolderPlus className="mr-2 h-4 w-4" /> Create Folder</Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-[425px]">
+                <DialogHeader><DialogTitle>Create New Folder</DialogTitle></DialogHeader>
+                <div className="grid gap-4 py-4">
+                    <Input id="name" placeholder="New folder name" value={folderName} onChange={(e) => setFolderName(e.target.value)} className="col-span-3" />
+                    {error && <p className="text-sm text-destructive">{error}</p>}
+                </div>
+                <DialogFooter>
+                    <DialogClose asChild><Button variant="ghost">Cancel</Button></DialogClose>
+                    <Button onClick={handleCreate}>Create</Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}


### PR DESCRIPTION
This commit adds key folder management capabilities to the application, significantly improving user navigation and organization within the S3 bucket.

Backend:
- Implements a new `POST /api/folders` endpoint to handle folder creation.
- The endpoint creates an empty S3 object with a trailing slash (`/`) to emulate a folder, which is the standard practice for S3.

Frontend:
- Introduces a new `BreadcrumbNav` component to display the current path and allow for quick, hierarchical navigation back to parent folders.
- Adds a `CreateFolderDialog` component, enabling users to create new folders in the current directory.
- Integrates the "Create Folder" button and the breadcrumb navigation into the main page header, providing a more intuitive user experience.