### PR TITLE
feat: implement file sharing and renaming

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,16 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+    images: {
+      remotePatterns: [
+        {
+          protocol: 'https',
+          // This allows images from any S3 bucket in your specified region.
+          // The hostname is constructed from your bucket name and region.
+          // Example: your-bucket-name.s3.us-east-1.amazonaws.com
+          hostname: `${process.env.AWS_BUCKET_NAME}.s3.${process.env.AWS_REGION}.amazonaws.com`,
+        },
+      ],
+    },
+  };
+  
+  module.exports = nextConfig;  

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -192,7 +192,7 @@ export default function HomePage() {
             onFolderClick={handleFolderClick}
             onNavigateUp={handleNavigateUp}
             currentPrefix={prefix}
-            onDeleteSuccess={fetchFiles}
+            onActionSuccess={fetchFiles}
           />
         )}
       </div>

--- a/frontend/src/components/RenameDialog.tsx
+++ b/frontend/src/components/RenameDialog.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogClose,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { FileItem, FolderItem } from './FileList';
+
+interface RenameDialogProps {
+  item: FileItem | FolderItem | null;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+  currentPrefix: string;
+}
+
+export function RenameDialog({ item, isOpen, onOpenChange, onSuccess, currentPrefix }: RenameDialogProps) {
+  const [newName, setNewName] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (item) {
+      setNewName(item.name);
+    }
+  }, [item]);
+
+  const handleRename = async () => {
+    if (!item || !newName || newName.includes('/')) {
+      setError('Invalid name. Cannot be empty or contain slashes.');
+      return;
+    }
+    setError('');
+
+    const isFolder = 'prefix' in item;
+    const oldKey = isFolder ? item.prefix : item.key;
+    const newKey = isFolder ? `${currentPrefix}${newName}/` : `${currentPrefix}${newName}`;
+
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/rename`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ oldKey, newKey, isFolder }),
+      });
+
+      if (!res.ok) {
+        const errorData = await res.json();
+        throw new Error(errorData.details || 'Failed to rename.');
+      }
+
+      onSuccess();
+      onOpenChange(false);
+    } catch (e) {
+      if (e instanceof Error) {
+        setError(e.message);
+      } else {
+        setError('An unexpected error occurred.');
+      }
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader><DialogTitle>Rename { 'prefix' in (item || {}) ? 'Folder' : 'File' }</DialogTitle></DialogHeader>
+        <div className="grid gap-4 py-4">
+          <Input id="name" value={newName} onChange={(e) => setNewName(e.target.value)} className="col-span-3" />
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+        <DialogFooter>
+          <DialogClose asChild><Button variant="ghost">Cancel</Button></DialogClose>
+          <Button onClick={handleRename}>Rename</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/ShareDialog.tsx
+++ b/frontend/src/components/ShareDialog.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { FileItem } from './FileList';
+import { Copy, Check } from 'lucide-react';
+
+interface ShareDialogProps {
+  file: FileItem | null;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ShareDialog({ file, isOpen, onOpenChange }: ShareDialogProps) {
+  const [expiry, setExpiry] = useState('3600'); // 1 hour in seconds
+  const [generatedUrl, setGeneratedUrl] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [isCopied, setIsCopied] = useState(false);
+
+  const handleGenerateLink = async () => {
+    if (!file) return;
+    setIsLoading(true);
+    setError('');
+    setGeneratedUrl('');
+    setIsCopied(false);
+
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/share/presigned-url`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key: file.key, expiresIn: expiry }),
+      });
+
+      if (!res.ok) {
+        const errorData = await res.json();
+        throw new Error(errorData.details || 'Failed to generate link.');
+      }
+      const { url } = await res.json();
+      setGeneratedUrl(url);
+    } catch (e) {
+      if (e instanceof Error) {
+        setError(e.message);
+      } else {
+        setError('An unexpected error occurred.');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleCopyToClipboard = () => {
+    navigator.clipboard.writeText(generatedUrl);
+    setIsCopied(true);
+    setTimeout(() => setIsCopied(false), 2000); // Reset after 2 seconds
+  };
+
+  const handleOpenChangeWithReset = (open: boolean) => {
+    if (!open) {
+      // Reset state when dialog closes
+      setGeneratedUrl('');
+      setError('');
+      setIsCopied(false);
+      setExpiry('3600');
+    }
+    onOpenChange(open);
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChangeWithReset}>
+      <DialogContent className="sm:max-w-[525px]">
+        <DialogHeader>
+          <DialogTitle>Share {`"${file?.name}"`}</DialogTitle>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="expiry" className="text-right">Expires in</Label>
+            <Select value={expiry} onValueChange={setExpiry}>
+              <SelectTrigger className="col-span-3"><SelectValue placeholder="Set expiry time" /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="3600">1 Hour</SelectItem>
+                <SelectItem value="86400">1 Day</SelectItem>
+                <SelectItem value="604800">7 Days</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          {generatedUrl && (
+            <div className="relative col-span-4">
+              <Input id="link" value={generatedUrl} readOnly />
+              <Button size="icon" variant="ghost" className="absolute right-1 top-1/2 -translate-y-1/2 h-7 w-7" onClick={handleCopyToClipboard}>
+                {isCopied ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
+              </Button>
+            </div>
+          )}
+          {error && <p className="text-sm text-destructive col-span-4">{error}</p>}
+        </div>
+        <DialogFooter>
+          <Button onClick={handleGenerateLink} disabled={isLoading}>{isLoading ? 'Generating...' : 'Generate Link'}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
This commit introduces two major user-facing features: the ability to generate secure, time-limited links for sharing files, and the ability to rename or move files and folders within the S3 bucket.

Backend:
- Adds a `POST /api/share/presigned-url` endpoint to generate temporary `GetObject` URLs with a user-defined expiration.
- Adds a `POST /api/rename` endpoint that handles both file and folder renaming by performing the necessary S3 `CopyObject` and `DeleteObject(s)` operations.
- Fixes a bug in the rename logic by URL-encoding the `CopySource` key to handle special characters in filenames.

Frontend:
- Creates a new `ShareDialog` component for generating and copying shareable links.
- Creates a new `RenameDialog` component for renaming files and folders.
- Integrates "Share" and "Rename" actions into the dropdown menu for each item in the `FileList`.
- Fixes an image preview bug by adding a `next.config.js` to authorize the S3 domain and using the `next/image` component.
- The main page now correctly passes an `onActionSuccess` callback to refresh the file list after any successful action.