### PR TITLE
feat: implement bulk file deletion

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -20,23 +20,29 @@ import { Terminal, Search } from 'lucide-react';
 
 const FileListSkeleton = () => (
   <div className="p-4 space-y-4">
-    <div className="grid grid-cols-[40px_1fr_150px_100px] items-center gap-4">
+    <div className="grid grid-cols-[60px_40px_1fr_150px_120px_50px] items-center gap-4">
+      <Skeleton className="h-5 w-5" />
       <Skeleton className="h-5 w-5" />
       <Skeleton className="h-4 w-[250px]" />
       <Skeleton className="h-4 w-[120px]" />
       <Skeleton className="h-4 w-[80px]" />
+      <Skeleton className="h-4 w-5" />
     </div>
-    <div className="grid grid-cols-[40px_1fr_150px_100px] items-center gap-4">
+    <div className="grid grid-cols-[60px_40px_1fr_150px_120px_50px] items-center gap-4">
+      <Skeleton className="h-5 w-5" />
       <Skeleton className="h-5 w-5" />
       <Skeleton className="h-4 w-[200px]" />
       <Skeleton className="h-4 w-[120px]" />
       <Skeleton className="h-4 w-[80px]" />
+      <Skeleton className="h-4 w-5" />
     </div>
-    <div className="grid grid-cols-[40px_1fr_150px_100px] items-center gap-4">
+    <div className="grid grid-cols-[60px_40px_1fr_150px_120px_50px] items-center gap-4">
+      <Skeleton className="h-5 w-5" />
       <Skeleton className="h-5 w-5" />
       <Skeleton className="h-4 w-[300px]" />
       <Skeleton className="h-4 w-[120px]" />
       <Skeleton className="h-4 w-[80px]" />
+      <Skeleton className="h-4 w-5" />
     </div>
   </div>
 );


### PR DESCRIPTION
This commit introduces the ability to select and delete multiple files at once, significantly improving the efficiency of file management within the application.

Backend:
- Adds a new `DELETE /api/files/bulk` endpoint that accepts an array of file keys.
- Utilizes the S3 `DeleteObjectsCommand` for efficient, single-request deletion of multiple objects.

Frontend:
- Adds checkboxes to each file row and a "Select All" checkbox in the `FileList` table header.
- Implements state management to track selected items.
- A contextual action bar now appears at the top of the file list when one or more items are selected, displaying the selection count and a "Delete Selected" button.
- A confirmation `AlertDialog` is shown before executing the bulk delete to prevent accidental data loss.
- The `FileListSkeleton` has been updated to reflect the new table layout with checkboxes.