### PR TITLE
feat: implement storage analytics dashboard

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,0 +1,18 @@
+import { AnalyticsDashboard } from "@/components/AnalyticsDashboard";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+
+export default function DashboardPage() {
+  return (
+    <main className="container mx-auto p-4 sm:p-6 lg:p-8">
+      <div className="flex items-center mb-6">
+        <Button asChild variant="outline" size="icon" className="mr-4">
+          <Link href="/"><ArrowLeft className="h-4 w-4" /></Link>
+        </Button>
+        <h1 className="text-2xl font-bold">Storage Analytics</h1>
+      </div>
+      <AnalyticsDashboard />
+    </main>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -16,7 +16,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Terminal, Search } from 'lucide-react';
+import { Terminal, Search, BarChart2 } from 'lucide-react';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
 
 const FileListSkeleton = () => (
   <div className="p-4 space-y-4">
@@ -151,6 +153,9 @@ export default function HomePage() {
             <BreadcrumbNav prefix={prefix} onNavigate={setPrefix} />
           </div>
           <div className="flex items-center gap-3">
+            <Button asChild variant="outline" size="icon">
+              <Link href="/dashboard"><BarChart2 className="h-4 w-4" /></Link>
+            </Button>
             <CreateFolderDialog currentPrefix={prefix} onSuccess={fetchFiles} />
             <UploadDialog currentPrefix={prefix} onUploadSuccess={fetchFiles} />
             <ThemeToggle />

--- a/frontend/src/components/AnalyticsDashboard.tsx
+++ b/frontend/src/components/AnalyticsDashboard.tsx
@@ -1,0 +1,155 @@
+
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Bar, BarChart, Pie, PieChart, ResponsiveContainer, XAxis, YAxis, Tooltip, Legend, Cell } from 'recharts';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Terminal, File as FileIcon, HardDrive } from 'lucide-react';
+import { formatBytes } from '@/lib/utils';
+
+interface AnalyticsData {
+  totalFiles: number;
+  totalSize: number;
+  topLargestFiles: { key: string; size: number; lastModified: string }[];
+  uploadTrend: { date: string; count: number }[];
+  fileTypeDistribution: { name: string; value: number }[];
+}
+
+const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#8884d8', '#ff4d4d'];
+
+export function AnalyticsDashboard() {
+  const [data, setData] = useState<AnalyticsData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchAnalytics = async () => {
+      try {
+        const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/analytics`);
+        if (!res.ok) {
+          throw new Error('Failed to fetch analytics data.');
+        }
+        const result = await res.json();
+        setData(result);
+      } catch (e) {
+        if (e instanceof Error) setError(e.message);
+        else setError('An unknown error occurred.');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchAnalytics();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <Skeleton className="h-32" />
+        <Skeleton className="h-32" />
+        <Skeleton className="h-80 md:col-span-2" />
+        <Skeleton className="h-80 md:col-span-2" />
+        <Skeleton className="h-96 md:col-span-4" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <Terminal className="h-4 w-4" />
+        <AlertTitle>Error</AlertTitle>
+        <AlertDescription>{error}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Total Files</CardTitle>
+          <FileIcon className="h-4 w-4 text-muted-foreground" />
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{data.totalFiles.toLocaleString()}</div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Total Size</CardTitle>
+          <HardDrive className="h-4 w-4 text-muted-foreground" />
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{formatBytes(data.totalSize)}</div>
+        </CardContent>
+      </Card>
+
+      <Card className="md:col-span-2">
+        <CardHeader>
+          <CardTitle>File Type Distribution</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ResponsiveContainer width="100%" height={200}>
+            <PieChart>
+              <Pie data={data.fileTypeDistribution} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={80} label>
+                {data.fileTypeDistribution.map((entry, index) => (
+                  <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                ))}
+              </Pie>
+              <Tooltip />
+              <Legend />
+            </PieChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+
+      <Card className="md:col-span-4">
+        <CardHeader>
+          <CardTitle>Upload Trend</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ResponsiveContainer width="100%" height={300}>
+            <BarChart data={data.uploadTrend}>
+              <XAxis dataKey="date" />
+              <YAxis />
+              <Tooltip />
+              <Legend />
+              <Bar dataKey="count" fill="#8884d8" name="Files Uploaded" />
+            </BarChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+
+      <Card className="md:col-span-4">
+        <CardHeader>
+          <CardTitle>Top 10 Largest Files</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>File</TableHead>
+                <TableHead>Size</TableHead>
+                <TableHead>Last Modified</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {data.topLargestFiles.map((file) => (
+                <TableRow key={file.key}>
+                  <TableCell className="font-medium truncate max-w-xs">{file.key}</TableCell>
+                  <TableCell>{formatBytes(file.size)}</TableCell>
+                  <TableCell>{new Date(file.lastModified).toLocaleDateString()}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,6 +1,0 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
-}

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1,0 +1,49 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+import { File, FileArchive, FileAudio, FileCode, FileImage, FileText, FileVideo } from "lucide-react";
+import React from "react";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+
+// Helper to format bytes into a readable string
+export const formatBytes = (bytes: number, decimals: number = 2): string => {
+  if (!+bytes) return '0 Bytes';
+  const k = 1024;
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
+};
+
+// Helper to get an icon based on file extension
+export const getFileIcon = (fileName: string): React.ReactElement => {
+  const extension = fileName.split('.').pop()?.toLowerCase();
+  switch (extension) {
+    case 'jpg':
+    case 'jpeg':
+    case 'png':
+    case 'gif':
+    case 'svg':
+    case 'webp':
+      return <FileImage className="h-5 w-5 text-muted-foreground" />;
+    case 'pdf':
+      return <FileText className="h-5 w-5 text-muted-foreground" />;
+    case 'zip':
+    case 'rar':
+    case '7z':
+      return <FileArchive className="h-5 w-5 text-muted-foreground" />;
+    case 'mp4':
+    case 'mov':
+    case 'avi':
+      return <FileVideo className="h-5 w-5 text-muted-foreground" />;
+    case 'mp3':
+    case 'wav':
+      return <FileAudio className="h-5 w-5 text-muted-foreground" />;
+    case 'js': case 'jsx': case 'ts': case 'tsx': case 'html': case 'css':
+      return <FileCode className="h-5 w-5 text-muted-foreground" />;
+    default:
+      return <File className="h-5 w-5 text-muted-foreground" />;
+  }
+};


### PR DESCRIPTION
This commit introduces a new analytics dashboard to provide users with valuable insights into their S3 bucket usage. The dashboard visualizes key metrics, helping users understand storage consumption and file distribution at a glance.

Backend:
- Adds a new `GET /api/analytics` endpoint.
- The endpoint performs full pagination over all objects in the bucket to gather comprehensive data.
- It calculates and aggregates key metrics: total file count, total size, top 10 largest files, monthly upload trends, and file type distribution.

Frontend:
- Adds `recharts` as a dependency for data visualization.
- Creates a new `/dashboard` page to host the analytics view.
- Implements an `AnalyticsDashboard` component that fetches data and renders it using cards, tables, a bar chart for upload trends, and a pie chart for file type distribution.
- Adds a link to the new dashboard in the main page header for easy access.
- Refactors helper functions (`formatBytes`, `getFileIcon`) into a shared `lib/utils.ts` file for better code organization and reusability.